### PR TITLE
fix: sheriff.config.ts

### DIFF
--- a/sheriff.config.ts
+++ b/sheriff.config.ts
@@ -2,14 +2,14 @@ import { sameTag, SheriffConfig } from '@softarc/sheriff-core';
 
 export const config: SheriffConfig = {
   modules: {
-    '@feature-booking': ['domain:booking', 'type:test-enforcement'],
-    '@feature-check-in': ['domain:check-in', 'type:feature'],
+    'libs/feature-booking/src/lib': ['domain:booking', 'type:test-enforcement'],
+    'libs/feature-check-in/src/lib': ['domain:check-in', 'type:feature'],
   },
   depRules: {
     'domain:*': [sameTag, 'shared'],
     'type:feature': ['type:feature', 'type:data'],
     root: ['type:feature', 'noTag'],
-    // noTag: ['type:feature', 'noTag', 'root'],
+    noTag: ['type:feature', 'noTag', 'root'],
   },
   enableBarrelLess: true,
 };


### PR DESCRIPTION
Replace TypeScript aliases with
the standard directory paths in
`sheriff.config.ts`.

In the CLI, run sheriff separately for every application.

For example
```bash
npx sheriff verify apps/booking/booking-mobile/src/main.ts
```